### PR TITLE
회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/example/demo/auth/controller/AuthController.java
+++ b/src/main/java/com/example/demo/auth/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.example.demo.common.ResponseUtil;
 import com.example.demo.auth.security.TokenProvider;
 import com.example.demo.auth.service.AuthService;
 
+import java.security.Principal;
 import java.util.concurrent.TimeUnit;
 
 import lombok.RequiredArgsConstructor;
@@ -69,20 +70,9 @@ public class AuthController {
         return ResponseUtil.SUCCESS(result);
     }
 
-    @DeleteMapping("/quit")
-    public ResponseEntity<?> quit(@RequestBody QuitDto request) {
-        var accessToken = request.getAccessToken();
-        if (!StringUtils.hasText(accessToken) || !this.tokenProvider.validateToken(accessToken)) {
-            return new ResponseEntity<>("Wrong Request", HttpStatus.BAD_REQUEST);
-        }
-        Authentication authentication = tokenProvider.getAuthentication(accessToken);
-        if (redisTemplate.opsForValue().get(authentication.getName()) != null) {
-            redisTemplate.delete(authentication.getName());
-        }
-        Long expiration = tokenProvider.getExpiration(accessToken);
-        redisTemplate.opsForValue().set(accessToken, "quit", expiration, TimeUnit.MILLISECONDS);
-
-        var result = this.authService.withdraw(request);
-        return new ResponseEntity<>("Quit Completed", HttpStatus.OK);
+    @DeleteMapping("/withdraw")
+    public void quit(Principal principal, @RequestBody PasswordRequestDto passwordRequestDto) {
+        var email = principal.getName();
+        authService.withdraw(email, passwordRequestDto.getPassword());
     }
 }

--- a/src/main/java/com/example/demo/auth/dto/PasswordRequestDto.java
+++ b/src/main/java/com/example/demo/auth/dto/PasswordRequestDto.java
@@ -1,0 +1,14 @@
+package com.example.demo.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PasswordRequestDto {
+    private String password;
+}

--- a/src/main/java/com/example/demo/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo/auth/service/AuthService.java
@@ -123,9 +123,6 @@ public class AuthService implements UserDetailsService {
         if (user.getAuthType().equals(AuthType.GENERAL) && !passwordEncoder.matches(password, user.getPassword())) {
             throw new RacketPuncherException(WRONG_PASSWORD);
         }
-        if (redisTemplate.opsForValue().get(email) == null) {
-            throw new RacketPuncherException(REFRESH_TOKEN_EXPIRED);
-        }
         redisTemplate.delete(email);
         siteUserRepository.delete(user);
         return SUCCESS_WITHDRAWAL;

--- a/src/main/java/com/example/demo/auth/service/AuthService.java
+++ b/src/main/java/com/example/demo/auth/service/AuthService.java
@@ -56,20 +56,6 @@ public class AuthService implements UserDetailsService {
         return this.siteUserRepository.save(SiteUser.fromDto(signUpDto));
     }
 
-    public void withdraw(String email, String password) {
-        var user = siteUserRepository.findByEmail(email)
-                .orElseThrow(() -> new RacketPuncherException(EMAIL_NOT_FOUND));
-
-        if (user.getAuthType().equals(AuthType.GENERAL) && !passwordEncoder.matches(password, user.getPassword())) {
-            throw new RacketPuncherException(WRONG_PASSWORD);
-        }
-        if (redisTemplate.opsForValue().get(email) == null) {
-            throw new RacketPuncherException(REFRESH_TOKEN_EXPIRED);
-        }
-        redisTemplate.delete(email);
-        siteUserRepository.delete(user);
-    }
-
     public SiteUser authenticate(SignInDto signInDto) {
         var user = siteUserRepository.findByEmail(signInDto.getEmail())
                 .orElseThrow(() -> new RacketPuncherException(EMAIL_NOT_FOUND));
@@ -128,5 +114,20 @@ public class AuthService implements UserDetailsService {
             throw new RacketPuncherException(NICKNAME_ALREADY_EXISTED);
         }
         return new StringResponseDto(VALID_NICKNAME);
+    }
+
+    public String withdraw(String email, String password) {
+        var user = siteUserRepository.findByEmail(email)
+                .orElseThrow(() -> new RacketPuncherException(EMAIL_NOT_FOUND));
+
+        if (user.getAuthType().equals(AuthType.GENERAL) && !passwordEncoder.matches(password, user.getPassword())) {
+            throw new RacketPuncherException(WRONG_PASSWORD);
+        }
+        if (redisTemplate.opsForValue().get(email) == null) {
+            throw new RacketPuncherException(REFRESH_TOKEN_EXPIRED);
+        }
+        redisTemplate.delete(email);
+        siteUserRepository.delete(user);
+        return SUCCESS_WITHDRAWAL;
     }
 }

--- a/src/test/java/com/example/demo/auth/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/demo/auth/controller/AuthControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientProviderBuilder;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -181,6 +182,21 @@ class AuthControllerTest {
                 .andDo(print());
     }
 
+    @Test
+    public void withdraw() throws Exception {
+        // given
+        given(authService.withdraw("email", getPasswordRequestDto().getPassword()))
+                .willReturn("탈퇴 성공");
+
+        // when
+        // then
+        mockMvc.perform(MockMvcRequestBuilders.delete("/api/auth/withdraw")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(new ObjectMapper().writeValueAsString(getPasswordRequestDto())))
+                .andExpect(MockMvcResultMatchers.status().isOk())
+                .andDo(print());
+    }
+
     private SignUpDto getSignUpDto() {
         return SignUpDto.builder()
                 .email("email@naver.com")
@@ -246,5 +262,9 @@ class AuthControllerTest {
 
     private NicknameRequestDto getNicknameRequestDto() {
         return new NicknameRequestDto("nickname");
+    }
+
+    private PasswordRequestDto getPasswordRequestDto() {
+        return new PasswordRequestDto("password");
     }
 }

--- a/src/test/java/com/example/demo/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/demo/auth/service/AuthServiceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.example.demo.entity.SiteUser;
 import com.example.demo.exception.RacketPuncherException;
@@ -28,6 +27,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -199,7 +201,113 @@ class AuthServiceTest {
         assertEquals(exception.getMessage(), "이미 사용 중인 닉네임입니다.");
     }
 
+    @Test
+    public void withdrawGeneralUserSuccess() {
+        // given
+        SiteUser generalSiteUser = getGeneralSiteUser();
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+        given(siteUserRepository.findByEmail(generalSiteUser.getEmail()))
+                .willReturn(Optional.of(generalSiteUser));
+        given(passwordEncoder.matches("password", generalSiteUser.getPassword()))
+                .willReturn(true);
+        given(redisTemplate.opsForValue())
+                .willReturn(valueOperations);
+        given(redisTemplate.opsForValue().get(generalSiteUser.getEmail()))
+                .willReturn("refreshToken");
+        given(redisTemplate.delete(generalSiteUser.getEmail()))
+                .willReturn(null);
+
+        // when
+        String result = authService.withdraw(generalSiteUser.getEmail(), "password");
+
+        // then
+        assertEquals(result, "탈퇴 성공");
+    }
+
+    @Test
+    public void withdrawKakaoUserSuccess() {
+        // given
+        SiteUser kakaoSiteUser = getKakaoSiteUser();
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+        given(siteUserRepository.findByEmail(kakaoSiteUser.getEmail()))
+                .willReturn(Optional.of(kakaoSiteUser));
+        given(redisTemplate.opsForValue())
+                .willReturn(valueOperations);
+        given(redisTemplate.opsForValue().get(kakaoSiteUser.getEmail()))
+                .willReturn("refreshToken");
+        given(redisTemplate.delete(kakaoSiteUser.getEmail()))
+                .willReturn(null);
+
+        // when
+        String result = authService.withdraw(kakaoSiteUser.getEmail(), "");
+
+        // then
+        assertEquals(result, "탈퇴 성공");
+    }
+
+    @Test
+    public void withdrawGeneralUserFailedByWrongPassword() {
+        // given
+        SiteUser generalSiteUser = getGeneralSiteUser();
+
+        given(siteUserRepository.findByEmail(generalSiteUser.getEmail()))
+                .willReturn(Optional.of(generalSiteUser));
+        given(passwordEncoder.matches("wrongPassword", generalSiteUser.getPassword()))
+                .willReturn(false);
+
+        // when
+        RacketPuncherException exception = assertThrows(RacketPuncherException.class,
+                () -> authService.withdraw(generalSiteUser.getEmail(), "wrongPassword"));
+
+        // then
+        assertEquals("비밀번호가 일치하지 않습니다.", exception.getMessage());
+    }
+
     private AccessTokenDto getAccessTokenDto() {
         return new AccessTokenDto("accessToken");
+    }
+
+    private SiteUser getGeneralSiteUser() {
+        return SiteUser.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .password(passwordEncoder.encode("password"))
+                .nickname("nickName")
+                .siteUserName("userName")
+                .phoneNumber("010-1234-5678")
+                .mannerScore(3.0)
+                .gender(GenderType.FEMALE)
+                .ntrp(Ntrp.BEGINNER)
+                .address("address")
+                .zipCode("zipCode")
+                .ageGroup(AgeGroup.TWENTIES)
+                .profileImg("img.png")
+                .isPhoneVerified(true)
+                .createDate(LocalDateTime.now())
+                .authType(AuthType.GENERAL)
+                .build();
+    }
+
+    private SiteUser getKakaoSiteUser() {
+        return SiteUser.builder()
+                .id(1L)
+                .email("email@naver.com")
+                .password("")
+                .nickname("nickName")
+                .siteUserName("userName")
+                .phoneNumber("010-1234-5678")
+                .mannerScore(3.0)
+                .gender(GenderType.FEMALE)
+                .ntrp(Ntrp.BEGINNER)
+                .address("address")
+                .zipCode("zipCode")
+                .ageGroup(AgeGroup.TWENTIES)
+                .profileImg("img.png")
+                .isPhoneVerified(true)
+                .createDate(LocalDateTime.now())
+                .authType(AuthType.KAKAO)
+                .build();
     }
 }

--- a/src/test/java/com/example/demo/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/demo/auth/service/AuthServiceTest.java
@@ -211,10 +211,6 @@ class AuthServiceTest {
                 .willReturn(Optional.of(generalSiteUser));
         given(passwordEncoder.matches("password", generalSiteUser.getPassword()))
                 .willReturn(true);
-        given(redisTemplate.opsForValue())
-                .willReturn(valueOperations);
-        given(redisTemplate.opsForValue().get(generalSiteUser.getEmail()))
-                .willReturn("refreshToken");
         given(redisTemplate.delete(generalSiteUser.getEmail()))
                 .willReturn(null);
 
@@ -233,10 +229,6 @@ class AuthServiceTest {
 
         given(siteUserRepository.findByEmail(kakaoSiteUser.getEmail()))
                 .willReturn(Optional.of(kakaoSiteUser));
-        given(redisTemplate.opsForValue())
-                .willReturn(valueOperations);
-        given(redisTemplate.opsForValue().get(kakaoSiteUser.getEmail()))
-                .willReturn("refreshToken");
         given(redisTemplate.delete(kakaoSiteUser.getEmail()))
                 .willReturn(null);
 


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 액세스 토큰을 Dto로 직접 받아왔습니다.
- 카카오 사용자와 일반 사용자를 구분하지 않았습니다.

**TO-BE**
- 스프링 시큐리티에서 제공하는 Principal 을 이용해 헤더의 jwt 토큰으로부터 이메일만 받아오게 하여 불필요한 데이터 중복 (헤더와 RequestBody에 모두 엑세스 토큰이 존재했던 것)을 없앴습니다.
- 카카오 사용자와 일반 사용자의 로직을 다르게 처리했습니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 