### PR TITLE
비동기로 스케쥴러가 작동할 수 있도록 설정 파일 추가

### DIFF
--- a/src/main/java/com/example/demo/config/AsyncConfiguration.java
+++ b/src/main/java/com/example/demo/config/AsyncConfiguration.java
@@ -1,0 +1,25 @@
+package com.example.demo.config;
+
+import java.util.concurrent.Executor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfiguration implements AsyncConfigurer {
+
+    @Override
+    @Bean(name = "taskExecutor") // @Async 어노테이션이 붙은 메서드를 사용할 때, 이 빈을 자동으로 찾아서 실행함.
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2); // 쓰레드 풀 기본 크기
+        executor.setMaxPoolSize(5); // 쓰레드 풀 최대 크기
+        executor.setQueueCapacity(500); // 작업 큐 용량(500개의 작업 대기 가능)
+        executor.setThreadNamePrefix("Async-"); // 쓰레드 생성할 때 앞에 접두어 붙임.
+        executor.initialize(); // 쓰레드 초기화 해줘야 설정한 쓰레드 풀이 실제로 사용 가능
+        return executor;
+    }
+}


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존에는 스케쥴러에 @Async 어노테이션만 달아놓고 비동기를 위한 설정을 추가하지 않았습니다. 
- 
**TO-BE**
- 멀티 스레드 환경에서 스케쥴러를 작동시키기 위해 비동기를 위한 설정 파일을 추가합니다. 
- 한 시간 간격으로 매칭 마감 시간이 되면 매칭을 종료시켜야하는 데, 싱글 스레드로 사용할 경우, 속도 이슈로 00분이 아닌 01분 이상의 시간이 가져와져 제대로 매칭 마감 처리가 이뤄지지 않을 수 도 있기 때문에 멀티 스레드 환경에서 작동할 수 있도록 설정합니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 