### PR TITLE
@Async 어노테이션과 @Transactional 어노테이션이 같이 사용되지 않도록 분리

### DIFF
--- a/src/main/java/com/example/demo/scheduler/Scheduler.java
+++ b/src/main/java/com/example/demo/scheduler/Scheduler.java
@@ -36,7 +36,6 @@ import java.util.Objects;
 @Slf4j
 @Component
 @RequiredArgsConstructor
-@Transactional
 public class Scheduler {
     private final MatchingRepository matchingRepository;
     private final NotificationService notificationService;
@@ -64,10 +63,12 @@ public class Scheduler {
 
     @Scheduled(cron = "${scheduler.cron.matches.confirm}")
     public void confirmResultsOfMatchesAtDueDate() {
-        log.info("Schedule for confirming matching is started at  " + LocalDateTime.now().format(formForDateTime));
-        getTimes().thenAccept(this::confirmResultsOfMatches);
+        DateTimeInfo dateTimeInfo = getTimes().join();
+        confirmResultsOfMatches(dateTimeInfo);
+        log.info("Schedule for confirming matching is finished at  " + LocalDateTime.now().format(formForDateTime));
     }
 
+    @Transactional
     public void confirmResultsOfMatches(DateTimeInfo dateTimeInfo) {
         List<Matching> matchesForConfirm
                 = matchingRepository.findAllByRecruitDueDateTime(dateTimeInfo.getRecruitDueDateTime());
@@ -153,6 +154,7 @@ public class Scheduler {
                 });
     }
 
+    @Transactional
     @Scheduled(cron = "${scheduler.cron.weather.notification}") // 매일 새벽 6시 30분에 수행
     public void checkWeatherAndSendNotification() {
         String now = LocalDate.now().format(formForDate);
@@ -167,6 +169,7 @@ public class Scheduler {
         }
     }
 
+    @Transactional
     @Scheduled(cron = "${scheduler.cron.notification.delete}") // 매일 00:30분에 수행
     public void deleteNotifications() {
         LocalDateTime threeDaysBeforeNow = LocalDateTime.now().minusDays(3);


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- @Transactional이 Scheduler 클래스 전체에 달려있어, @Async 어노테이션과 @Transactional 어노테이션이 함께 쓰이고 있었습니다. 
- getTimes() 메서드를 비동기로 실행한 후, 해당 스레드에서 동기적으로 데이터에 접근하는 로직이었어서, 기존 스레드에서 db에 동시에 접근할 경우 동시성을 막기 힘든 구조였습니다. 

**TO-BE**
- @Async와 @Transactional 어노테이션을 분리하기 위해 동기 작업이 필요한 메서드에만 @Transactional 어노테이션을 붙여줍니다.
-  join()을 사용해 비동기 작업의 결과가 나올 때까지 기존 스레드를 블로킹 상태로 만들고, 현재 시간이 비동기로 가져와 지면 기존의 스레드에서 동기 작업으로 데이터베이스를 수정할 수 있도록  로직을 분리합니다.
