### PR TITLE
매칭별 신청 현황 조회 api 예외 처리 추가

### DIFF
--- a/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
@@ -222,8 +222,11 @@ public class MatchingServiceImpl implements MatchingService {
         var applyNum = applyRepository.countByMatching_IdAndApplyStatus(matchingId, ApplyStatus.PENDING).orElse(0);
         var appliedMembers = findAppliedMembers(matchingId);
         var acceptedMembers = findAcceptedMembers(matchingId);
-        var isApplied = applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId).isPresent();
-
+        var apply =  applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId);
+        var isApplied = true;
+        if (apply.isEmpty() || ApplyStatus.CANCELED.equals(apply.get().getApplyStatus())) {
+            isApplied = false;
+        }
         if (isOrganizer(siteUser.getId(), matching)) {
             return ApplyContents.builder()
                     .isApplied(isApplied)

--- a/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
@@ -222,11 +222,7 @@ public class MatchingServiceImpl implements MatchingService {
         var applyNum = applyRepository.countByMatching_IdAndApplyStatus(matchingId, ApplyStatus.PENDING).orElse(0);
         var appliedMembers = findAppliedMembers(matchingId);
         var acceptedMembers = findAcceptedMembers(matchingId);
-        var isApplied = true;
-        var apply = applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId);
-        if (apply.isEmpty() || ApplyStatus.CANCELED.equals(apply.get().getApplyStatus())) {
-            isApplied = false;
-        }
+        var isApplied = applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId).isPresent();
 
         if (isOrganizer(siteUser.getId(), matching)) {
             return ApplyContents.builder()

--- a/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
@@ -222,7 +222,11 @@ public class MatchingServiceImpl implements MatchingService {
         var applyNum = applyRepository.countByMatching_IdAndApplyStatus(matchingId, ApplyStatus.PENDING).orElse(0);
         var appliedMembers = findAppliedMembers(matchingId);
         var acceptedMembers = findAcceptedMembers(matchingId);
-        var isApplied = applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId).isPresent();
+        var isApplied = true;
+        var apply = applyRepository.findBySiteUser_IdAndMatching_Id(siteUser.getId(), matchingId);
+        if (apply.isEmpty() || ApplyStatus.CANCELED.equals(apply.get().getApplyStatus())) {
+            isApplied = false;
+        }
 
         if (isOrganizer(siteUser.getId(), matching)) {
             return ApplyContents.builder()

--- a/src/test/java/com/example/demo/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/com/example/demo/matching/controller/MatchingControllerTest.java
@@ -275,6 +275,7 @@ class MatchingControllerTest {
 
     private ApplyContents makeApplyContents() {
         return ApplyContents.builder()
+                .isApplied(true)
                 .applyNum(1)
                 .recruitNum(4)
                 .acceptedNum(1)

--- a/src/test/java/com/example/demo/matching/controller/MatchingControllerTest.java
+++ b/src/test/java/com/example/demo/matching/controller/MatchingControllerTest.java
@@ -275,7 +275,6 @@ class MatchingControllerTest {
 
     private ApplyContents makeApplyContents() {
         return ApplyContents.builder()
-                .isApplied(true)
                 .applyNum(1)
                 .recruitNum(4)
                 .acceptedNum(1)

--- a/src/test/java/com/example/demo/matching/service/MatchingServiceImplTest.java
+++ b/src/test/java/com/example/demo/matching/service/MatchingServiceImplTest.java
@@ -166,7 +166,7 @@ class MatchingServiceImplTest {
                 .willReturn(getApplyMember());
         given(applyRepository.findAllByMatching_IdAndApplyStatus(1L, ApplyStatus.ACCEPTED))
                 .willReturn(getConfirmedMember());
-         given(applyRepository.findBySiteUser_IdAndMatching_Id(getSiteUser().getId(), 1L))
+        given(applyRepository.findBySiteUser_IdAndMatching_Id(getSiteUser().getId(), 1L))
                  .willReturn(Optional.ofNullable(Apply.builder()
                          .siteUser(getSiteUser())
                          .applyStatus(ApplyStatus.PENDING)

--- a/src/test/java/com/example/demo/matching/service/MatchingServiceImplTest.java
+++ b/src/test/java/com/example/demo/matching/service/MatchingServiceImplTest.java
@@ -166,7 +166,7 @@ class MatchingServiceImplTest {
                 .willReturn(getApplyMember());
         given(applyRepository.findAllByMatching_IdAndApplyStatus(1L, ApplyStatus.ACCEPTED))
                 .willReturn(getConfirmedMember());
-        given(applyRepository.findBySiteUser_IdAndMatching_Id(getSiteUser().getId(), 1L))
+         given(applyRepository.findBySiteUser_IdAndMatching_Id(getSiteUser().getId(), 1L))
                  .willReturn(Optional.ofNullable(Apply.builder()
                          .siteUser(getSiteUser())
                          .applyStatus(ApplyStatus.PENDING)


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤 점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존에는 매칭별 신청 현황을 조회할 때, 취소된 신청이라도 신청 내역은 삭제가 되지 않고, 신청 상태만 변경이 되었기 때문에 isApplied가 true가 나왔습니다. 
**TO-BE**
- 위 예외 상황을 해결하기 위해 신청 상태가 CANCELED이거나, 조회한 Optional(Apply)가 empty인 경우 false로 반환하도록 로직을 수정합니다.

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [x] 테스트 코드
- [x] API 테스트 