### PR TITLE
fix: SSE 연결을 하는 api 경우 헤더에 접근할 수가 없어 @PathVariable로 토큰 정보를 전달

### DIFF
--- a/src/main/java/com/example/demo/auth/security/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/demo/auth/security/JwtAuthenticationFilter.java
@@ -73,6 +73,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         permitAllEndpoints.add("/api/auth/sign-in/**");
         permitAllEndpoints.add("/api/auth/reissue");
         permitAllEndpoints.add("/api/auth/upload-profile-image");
+        permitAllEndpoints.add("/api/notifications/connect/**");
         permitAllEndpoints.add("/api/matches/list/**");
         permitAllEndpoints.add("/api/matches/detail/**");
         permitAllEndpoints.add("/api/matches/address");

--- a/src/main/java/com/example/demo/auth/security/SecurityConfiguration.java
+++ b/src/main/java/com/example/demo/auth/security/SecurityConfiguration.java
@@ -51,10 +51,10 @@ public class SecurityConfiguration {
                 .authorizeHttpRequests(authorizeRequest
                         -> authorizeRequest
                         .requestMatchers("/api/auth/sign-up", "/api/auth/sign-in/**", "/api/auth/reissue",
-                                "/api/auth/upload-profile-image",  "/api/matches/list/**",
-                                "/api/matches/detail/**", "/api/users/profile/**", "/api/aws/**",
-                                "/api/auth/check-nickname", "/api/auth/check-email", "/api/auth/redis",
-                                "/api/auth/kakao", "/api/matches/address", 
+                                "/api/auth/upload-profile-image", "/api/notifications/connect/**",
+                                "/api/matches/list/**", "/api/matches/detail/**", "/api/users/profile/**",
+                                "/api/aws/**", "/api/auth/check-nickname", "/api/auth/check-email",
+                                "/api/auth/redis", "/api/auth/kakao", "/api/matches/address",
                                 "/api/auth/phone/send-code", "/api/auth/phone/verify-code",
                                 "/api/auth/find-id", "/api/auth/password/verify-user", "/api/auth/password/reset",
                                 "/ws", "/ws/**", "/chat-room.html", "/chat-room.js","/chat-list.html",

--- a/src/main/java/com/example/demo/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/demo/notification/controller/NotificationController.java
@@ -1,10 +1,14 @@
 package com.example.demo.notification.controller;
 
+import com.example.demo.auth.dto.AccessTokenDto;
+import com.example.demo.auth.security.TokenProvider;
 import com.example.demo.notification.service.NotificationService;
 import com.example.demo.siteuser.repository.SiteUserRepository;
 import java.security.Principal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
@@ -17,10 +21,11 @@ public class NotificationController {
 
     private final NotificationService notificationService;
     private final SiteUserRepository siteUserRepository;
-    @GetMapping("/connect")
-    public SseEmitter connect(Principal principal) {
+    private final TokenProvider tokenProvider;
+    @GetMapping("/connect/{accessToken}")
+    public SseEmitter connect(@PathVariable(value = "accessToken") String accessToken) {
 
-        String email = principal.getName();
+        String email = tokenProvider.getUserEmail(accessToken);
         var siteUser = siteUserRepository.findByEmail(email);
         return notificationService.connectNotification(siteUser.get().getId());
     }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 기존에는 헤더의 토큰 정보에서 사용자 정보를 불러오는 로직으로 SSE 연결 api를 구현하였습니다. 
**TO-BE**
- 프론트엔드에서 SSE를 연결 시도를 할 때, eventSource를 통해 api를 호출하기 때문에 http 요청과는 달리 헤더를 조작할 수 없다는 피드백을 받게 되어 @PathVariable로 토큰 정보를 받도록 수정합니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 