### PR TITLE
fix: 매칭 데이터 저장 시, 날씨 open api 관련 리팩터링 

### DIFF
--- a/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
+++ b/src/main/java/com/example/demo/matching/service/MatchingServiceImpl.java
@@ -16,6 +16,7 @@ import com.example.demo.siteuser.repository.SiteUserRepository;
 import com.example.demo.type.ApplyStatus;
 import com.example.demo.type.NotificationType;
 import com.example.demo.type.PenaltyType;
+import com.example.demo.type.PrecipitationType;
 import com.example.demo.type.RecruitStatus;
 import com.example.demo.util.geometry.GeometryUtil;
 import lombok.RequiredArgsConstructor;
@@ -71,7 +72,7 @@ public class MatchingServiceImpl implements MatchingService {
         }
         var weatherDto = weatherService.getWeatherResponseDtoByMatching(matching);
 
-        if (weatherDto != null) {
+        if (!PrecipitationType.NICE.equals(weatherDto.getPrecipitationType())) {
             matching.changeRecruitStatus(RecruitStatus.WEATHER_ISSUE);
             notificationService.createAndSendNotification(siteUser, matching,
                     NotificationType.makeWeatherIssueMessage(weatherDto));


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
- 날씨 데이터가 맑음이 아닌 경우를 기존에는 null이 아닌 경우로 처리를 했습니다. 
**TO-BE**
- 날씨 데이터가 맑음이 아닌 경우를 null이 아니라 NICE라는 Enum 값으로 저장함에 따라, 날씨 데이터가 NICE가 아닌 경우, 날씨 알림을 전송하는 로직으로 변경합니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 