### PR TITLE
fix: 응답 형태를 event-stream 형태로 반환하도록 수정

### DIFF
--- a/src/main/java/com/example/demo/notification/controller/NotificationController.java
+++ b/src/main/java/com/example/demo/notification/controller/NotificationController.java
@@ -3,6 +3,8 @@ package com.example.demo.notification.controller;
 import com.example.demo.auth.security.TokenProvider;
 import com.example.demo.common.ResponseDto;
 import com.example.demo.common.ResponseUtil;
+import com.example.demo.exception.RacketPuncherException;
+import com.example.demo.exception.type.ErrorCode;
 import com.example.demo.notification.service.NotificationService;
 import com.example.demo.siteuser.repository.SiteUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,11 +25,11 @@ public class NotificationController {
     private final SiteUserRepository siteUserRepository;
     private final TokenProvider tokenProvider;
     @GetMapping(value = "/connect/{accessToken}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
-    public ResponseDto<SseEmitter> connect(@PathVariable(value = "accessToken") String accessToken) {
+    public SseEmitter connect(@PathVariable(value = "accessToken") String accessToken) {
 
         String email = tokenProvider.getUserEmail(accessToken);
-        var siteUser = siteUserRepository.findByEmail(email);
-        var result = notificationService.connectNotification(siteUser.get().getId());
-        return ResponseUtil.SUCCESS(result);
+        var siteUser = siteUserRepository.findByEmail(email)
+                .orElseThrow(() -> new RacketPuncherException(ErrorCode.USER_NOT_FOUND));
+        return notificationService.connectNotification(siteUser.getId());
     }
 }


### PR DESCRIPTION
### 변경사항
<!-- 이 PR에서 어떤점들이 변경되었는지 기술해주세요. 가급적이면 as-is, to-be를 활용해서 작성해주세요.  -->
**AS-IS**
아래와 같은 에러가 발생했습니다. 
EventSource's response has a MIME type ("text/plain") that is not "text/event-stream". Aborting the connection.

**TO-BE**
응답 형태를 공용 응답 형식에 맞춰 발생한 문제였습니다.
SseEmitter를 바로 반환하도록 로직을 수정합니다. 

### 테스트
<!-- 본 변경사항이 테스트가 되었는지 기술해주세요 --> 
- [ ] 테스트 코드
- [ ] API 테스트 